### PR TITLE
Disable linting on push outside the main branch

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,8 +1,10 @@
 name: linting
 
 on:  # yamllint disable-line rule:truthy
-- pull_request
-- push
+  pull_request:
+  push:
+    branches:
+    - main
 
 jobs:
   markdown-lint:


### PR DESCRIPTION
Github actions do not need to run on push outside the main branch since they will run on the pull request anyway. One could say that it would break if no pull request is opened, so open a pull request !

Without this patch, we end up with the actions running twice, such as :

- https://github.com/badouralix/coding-best-practices/actions/runs/664427023
- https://github.com/badouralix/coding-best-practices/actions/runs/664427684