### PR TITLE
Rename lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: linting
+name: lint
 
 on:  # yamllint disable-line rule:truthy
   pull_request:


### PR DESCRIPTION
With other workflow names such as `buildx`, it feels better to use `lint` instead of `linting`